### PR TITLE
Feature/modification as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ A release MAY provide a list of **fixed** functionality.
 
 A release MAY provide a list of **secured** fixes.
 
+All modification list items MUST be either string or an object with a
+**title** property.
+
 ## Related Projects
 
 - [keep a changelog](http://keepachangelog.com)

--- a/release-notes.yml
+++ b/release-notes.yml
@@ -6,6 +6,7 @@ releases:
 - version: Upcoming
   added:
   - Add support for an optional release title.
+  - Add support for defining modifications as string or object with title attribute.
 - version: 0.1.0
   date: 2017-07-07T11:35:00Z
   description: The first released draft of the release notes specification.


### PR DESCRIPTION
Allow for defining modifications as object.
This will be extended with more meta-data in a later version (eg. reference issues, note the author etc.)